### PR TITLE
zd戦略に自動調整するボタンを設置

### DIFF
--- a/GUI_PDgame.py
+++ b/GUI_PDgame.py
@@ -1,6 +1,6 @@
 #-*-coding:utf-8-*-
 import numpy as np
-#import sympy as sp
+import sympy as sp
 import numpy.linalg as LA
 import random
 import tkinter
@@ -124,6 +124,7 @@ def PD(l,p,q,f,epsilon,xi,w):
               ]
 
         return 2*q[l]*LA.det(pD1) +LA.det(pD2) +LA.det(pD3)
+    """
     else:
         s = (PD(0,p,q,f,epsilon,xi,w)**2
             + PD(1,p,q,f,epsilon,xi,w)**2
@@ -131,6 +132,7 @@ def PD(l,p,q,f,epsilon,xi,w):
             + PD(3,p,q,f,epsilon,xi,w)**2
             + PD(4,p,q,f,epsilon,xi,w)**2)
         return .8 if s < 0.00001 else 0.
+    """
 
 
 def Calculation_Determinant(p,q_list,epsilon,xi,Sx,Sy,w):
@@ -196,9 +198,16 @@ def Calculation_Inverse(p,q_list,epsilon,xi,Sx,Sy,w):
 def Calc_Partial_Derivative(l, p, q_list, epsilon, xi, Sx, w):
     one = [1.,1.,1.,1.]
     rlist = []
-    for q in q_list:
-        rlist.append(D(p,q,one,epsilon,xi,w) * PD(l,p,q,Sx,epsilon,xi,w) 
-                    -PD(l,p,q,one,epsilon,xi,w) * D(p,q,Sx,epsilon,xi,w))
+    if l < 5:
+        for q in q_list:
+            rlist.append(D(p,q,one,epsilon,xi,w) * PD(l,p,q,Sx,epsilon,xi,w) 
+                        -PD(l,p,q,one,epsilon,xi,w) * D(p,q,Sx,epsilon,xi,w))
+    else :
+        for q in q_list:
+            s = 0.
+            for i in range(5):
+                s += (D(p,q,one,epsilon,xi,w) * PD(i,p,q,Sx,epsilon,xi,w) -PD(i,p,q,one,epsilon,xi,w) * D(p,q,Sx,epsilon,xi,w))**2
+            rlist.append(10. if s < 1E-10 else 0.)
 
     return rlist
 
@@ -220,7 +229,10 @@ def Quit():
 
 def change_q(canvas, ax):
     global q_list
-    q_list=[[random.random(),random.random(),random.random(),random.random(),random.random()] for i in range(1000)]
+    if corner_case_flag:
+        q_list=[[float(format(i,'05b')[0]),float(format(i,'05b')[1]),float(format(i,'05b')[2]),float(format(i,'05b')[3]),float(format(i,'05b')[4])] for i in range(32)]
+    else:
+        q_list=[[random.random(),random.random(),random.random(),random.random(),random.random()] for i in range(1000)]
     txt.delete(0, tkinter.END)
     txt.insert(tkinter.END,"changed opponents")
     Select_DrawCanvas(canvas, ax, colors = "gray")
@@ -231,6 +243,7 @@ def change_5310(canvas, ax):
         T,R,P,S=1.5,1,0,-0.5
     else:
         T,R,P,S=5,3,1,0
+        #T,R,P,S=4.1,4,2,-1
     Select_DrawCanvas(canvas, ax, colors = "gray")
 
 def save_fig():
@@ -399,19 +412,63 @@ def DrawCanvas_adapting_path(canvas, ax, colors = "gray"):
 
     q_list.append([0,0,0,0,0]); q_list.append([1,1,1,1,1]);
     y,x = Select_Method_Calculation(p,q_list,epsilon,xi,Sx,Sy,w,option)
-    mx = scale8.get()/100.
+    #mx = scale8.get()/100.
+    #mx = np.exp(scale8.get()/1000.) -1.
+    #mx = np.log(scale8.get()/1000.+1.)
+    mx = (scale8.get()/1000.)**3
     
     if pd_Sx_flag:
         pds = Calc_Partial_Derivative(l,p,q_list,epsilon,xi,Sx,w)
     else:
         pds = Calc_Partial_Derivative(l,p,q_list,epsilon,xi,Sy,w)
     if l < 5:
-        plt.scatter(y, x, s=20, c=pds, alpha=1, linewidths=0.1, edgecolors='k', cmap='bwr_r', vmin=-mx, vmax=mx, zorder=2)
+        plt.scatter(y, x, s=20, c=pds, alpha=.5, linewidths=0.1, edgecolors='k', cmap='bwr_r', vmin=-mx, vmax=mx, zorder=2)
     else:
         plt.scatter(y, x, s=20, c=pds, alpha=.5, linewidths=0.2, edgecolors='k', cmap='Reds', zorder=2)
     #plt.rcParams["font.size"] = 15
     
     canvas.draw()
+
+
+def adjust_zd(l,scale_l):
+    w=round(1-scale5.get()/100,2)
+    epsilon=round(scale6.get()/1000,3)
+    xi=round(scale7.get()/1000,3)
+    i=1000#stride
+    p=[scale0.get()/i,scale1.get()/i,scale2.get()/i,scale3.get()/i,scale4.get()/i]
+    SE = S*(1-epsilon-xi)+R*(epsilon+xi)
+    TE = T*(1-epsilon-xi)+P*(epsilon+xi)
+
+
+    sp.var('p0_ p1_ p2_ p3_ p4_ delta_ T_ S_')
+    
+    pv = [p0_,p1_,p2_,p3_,p4_]
+    pl = pv[l]
+    
+    subs_list = [(pv[i], p[i]) for i in range(5) if i != l]
+    subs_list.extend([(T_, TE),(S_,SE),(delta_,w)])
+    
+    eq = 1 +2*delta_*p4_ -(1 -delta_*p1_ +delta_*p4_)*(T_+S_) -delta_*p2_ -delta_*p3_
+    #display(sp.solve(eq.subs(subs_list), pl))
+    #return sp.solve(eq.subs(subs_list), pl)
+    s = sp.solve(eq.subs(subs_list), pl)[0]
+
+    if 0. <= s <= 1.:
+        p[l] = s
+        scale_l.set(int(round(s*1000)))
+        txt.delete(0, tkinter.END)
+        txt.insert(tkinter.END, f"Adjusted p{l}: p=[{p[0]:.3f},{p[1]:.3f},{p[2]:.3f},{p[3]:.3f},{p[4]:.3f}]")
+
+        Select_DrawCanvas(Canvas, ax1)
+    else:
+        txt.delete(0, tkinter.END)
+        txt.insert(tkinter.END, f"Error: there's no suitable value in [0,1]")
+
+
+
+
+
+
 
 
 def _set_pd_Sx_flag(event):
@@ -421,14 +478,24 @@ def _set_pd_Sx_flag(event):
     switch_view(Canvas, ax1, draw_coord)
     Select_DrawCanvas(Canvas, ax1)
 
+def _set_corner_case_flag(event):
+    global corner_case_flag
+
+    corner_case_flag = not(corner_case_flag)
+    change_q(Canvas, ax1)
+    Select_DrawCanvas(Canvas, ax1)
+
+
 draw_coord = True
 pd_Sx_flag = True
+corner_case_flag = False
 
 if __name__ == "__main__":
     try:
         #generate GUI
         root = tkinter.Tk()
-        root.geometry("700x550")
+        root.geometry("750x550")
+        #root.geometry("700x550")
         root.title("GUI- vs 1,000+2 Strategies Under Discounting and Observation Errors in RPD game")
         
         #generate graph
@@ -438,7 +505,8 @@ if __name__ == "__main__":
         #generate Canvas
         Canvas = FigureCanvasTkAgg(fig, master=root)
         Canvas.get_tk_widget().grid(row=0, column=0, rowspan=1000)
-        T,R,P,S=1.5,1,0,-0.5
+        T,R,P,S=1.1,1,0,-1.
+        #T,R,P,S=1.5,1,0,-0.5
         option=0
         q_list=[[random.random(),random.random(),random.random(),random.random(),random.random()] for i in range(1000)]
         
@@ -466,13 +534,24 @@ if __name__ == "__main__":
         scale3.grid(row=5, column=3, columnspan=1)
         scale4 = tkinter.Scale(root, label='p4',orient='h', from_=0, to=1000, command=partial(Select_DrawCanvas, Canvas, ax1))
         scale4.grid(row=6, column=3, columnspan=1)
-        
+
         scale5 = tkinter.Scale(root, label='discount rate',orient='h', from_=0, to=100, command=partial(Select_DrawCanvas, Canvas, ax1))
         scale5.grid(row=2, column=1, columnspan=1)
         scale6 = tkinter.Scale(root, label='epsilon',orient='h', from_=0, to=300, command=partial(Select_DrawCanvas, Canvas, ax1))
         scale6.grid(row=3, column=1, columnspan=1)
         scale7 = tkinter.Scale(root, label='xi', orient='h', from_=0, to=300, command=partial(Select_DrawCanvas, Canvas, ax1))
         scale7.grid(row=4, column=1, columnspan=1)
+
+        # for adjust to zd strategy
+        AdjustButton = tkinter.Button(text='zd', width=2, command=partial(adjust_zd, 1, scale1))
+        AdjustButton.grid(row=3, column=4, columnspan=1)
+        AdjustButton = tkinter.Button(text='zd', width=2, command=partial(adjust_zd, 2, scale2))
+        AdjustButton.grid(row=4, column=4, columnspan=1)
+        AdjustButton = tkinter.Button(text='zd', width=2, command=partial(adjust_zd, 3, scale3))
+        AdjustButton.grid(row=5, column=4, columnspan=1)
+        AdjustButton = tkinter.Button(text='zd', width=2, command=partial(adjust_zd, 4, scale4))
+        AdjustButton.grid(row=6, column=4, columnspan=1)
+        
 
         # for partial derivative view 
         view_var = tkinter.StringVar()
@@ -483,8 +562,9 @@ if __name__ == "__main__":
         listbox.grid(row=8, column=3, rowspan=4, columnspan=1)
         listbox.bind('<<ListboxSelect>>', lambda event: switch_view(Canvas, ax1, False))
 
-        root.bind("<KeyPress-v>", lambda event: switch_view(Canvas, ax1, True))
-        root.bind("<Shift-KeyPress-V>", _set_pd_Sx_flag)
+        root.bind("<KeyPress-p>", lambda event: switch_view(Canvas, ax1, True))
+        root.bind("<Shift-KeyPress-P>", _set_pd_Sx_flag)
+        root.bind("<Shift-KeyPress-C>", _set_corner_case_flag)
 
         scale8 = tkinter.Scale(root, label='PD max', orient='h', from_=0, to=200, command=partial(Select_DrawCanvas, Canvas, ax1))
         scale8.set(10)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - (0)Detは本研究で見つけた行列式で計算する方法，(1)はHilbe et al.,2015,GEBで示された逆行列の形で計算する方法である
 - 割引因子<img src="https://latex.codecogs.com/gif.latex?w">，エラー率<img src="https://latex.codecogs.com/gif.latex?\epsilon,\xi">は，スライダーで変更できる
 - 戦略<img src="https://latex.codecogs.com/gif.latex?{\bf%20p}=(p_1,p_2,p_3,p_4),p_0=1">の値もスライダーから変更できる．1,000分の1単位で値を変えることができる．
+- 横のzdボタンを押すと，ZD戦略となる値に自動調整してくれる（ZD戦略となる値がある場合のみ）
 ### ボタン
 - Other Opponent
   - 相手の戦略<img src="https://latex.codecogs.com/gif.latex?{\bf%20q}">の値を別のランダムな値に変更する．
@@ -42,11 +43,14 @@
 #### スライダー
 カラーマップの最大・最小値の絶対値を決める（小さくするほど0に近い偏微分の値が色に現れやすくなる）
 
-#### ショートカットキー
-* v
+
+### ショートカットキー
+* p:
   - 通常モードと偏微分係数モードを切り替える（Switch Nomal/APボタンと同じ機能）．
-* Shift+v
+* Shift+p:
   - 偏微分係数を計算する際，プレイヤーXの利得についての偏微分（<img src="https://latex.codecogs.com/gif.latex?\partial"><img src="https://latex.codecogs.com/gif.latex?s_X/\partial"><img src="https://latex.codecogs.com/gif.latex?q_i">) かプレイヤーYの利得の偏微分 (<img src="https://latex.codecogs.com/gif.latex?\partial"><img src="https://latex.codecogs.com/gif.latex?s_Y/\partial"><img src="https://latex.codecogs.com/gif.latex?q_i">) かを切り替える．
+* Shift+c:
+  - 相手の戦略<img src="https://latex.codecogs.com/gif.latex?{\bf%20q}">の値をコーナーケースに設定する．
 
 ## UIの例
 ### 条件


### PR DESCRIPTION
p1~p4のスライダー横にあるボタンを押すとZD戦略となるように自動調整される（[0,1]内にZD戦略となりうる値が存在する場合のみ）

微調整として、
* 偏微分モード/SxとSy切り替え のショートカットを p/Shift+p に変更したので注意
* 表示されるqをコーナーケースのものに限るショートカット : Shift+c